### PR TITLE
Fix/deps declaration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiozipkin==1.0.0
-starlette==0.14.1
+starlette==0.16.0

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@ import re
 
 from setuptools import setup
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
 
 def get_version(package):
     """
@@ -47,7 +44,10 @@ setup(
     author="Michal Vala",
     author_email="mic.vala@gmail.com",
     packages=get_packages("starlette_zipkin"),
-    install_requires=requirements,
+    install_requires=[
+        'aiozipkin <2',
+        'starlette >0.14,<18',
+    ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",


### PR DESCRIPTION
Hello @mchlvl 

Currently you are using a requirements.txt file to declare your dependencies,
and your dependencies are not up to date.

As a result, zip starlette plugin is neither usable with the last version of fastapi ([0.16](https://github.com/tiangolo/fastapi/blob/master/pyproject.toml#L36)), nor the last version of starlette ([0.17](https://pypi.org/project/starlette/)).

By the way, it is not a good idea to use a requirements.txt to declare dependencies,
in a correct flow, this file are all the frozen dependencies (generarate with the command pip freeze > requirements.txt).
