### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.0 (Dec 19, 2021)
+
+### Changed
+- [PR21](https://github.com/mchlvl/starlette-zipkin/pull/21) code refactor, new functionality, added `trace` context manager to add spans easier and updated examples, tests, readme
+
+
 ## 0.1.4 (Dec 16, 2021)
 
 ### Changed

--- a/starlette_zipkin/__init__.py
+++ b/starlette_zipkin/__init__.py
@@ -2,7 +2,7 @@ from starlette_zipkin.header_formatters import B3Headers, UberHeaders
 from starlette_zipkin.middleware import ZipkinConfig, ZipkinMiddleware, get_ip
 from starlette_zipkin.trace import get_root_span, get_tracer, trace
 
-__version__ = "0.1.4"
+__version__ = "0.2.0"
 __all__ = [
     "ZipkinConfig",
     "ZipkinMiddleware",


### PR DESCRIPTION
## 0.2.0 (Dec 19, 2021)

### Changed
- [PR21](https://github.com/mchlvl/starlette-zipkin/pull/21) code refactor, new functionality, added `trace` context manager to add spans easier and updated examples, tests, readme
