### PR TITLE
Close tracer when returning a response (cpu leak)

### DIFF
--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -1,3 +1,4 @@
+import asyncio
 import socket
 import traceback
 import urllib
@@ -47,7 +48,7 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
                 self.before(span, request.scope)
                 response = await call_next(request)
                 self.after(span, response)
-
+                asyncio.get_event_loop().create_task(tracer.close())
                 return response
 
             except Exception as error:


### PR DESCRIPTION
Hello!

I have found a CPU leak on `starlette-zipkin`. I noticed that the service load was getting linearly increasingly higher as long as more requests were served. After some debugging I've found out that the middleware spans a new `aiozipkin` trace and does not terminate it.

The background is the `aiozipkin` internals, where it uses a `Transport()` ([link](https://github.com/aio-libs/aiozipkin/blob/89fa9f8cc5d008b0f5ce4d40c2b5af8a42b9c011/aiozipkin/transport.py#L120)) object, in which inside has a `BatchManager()` ([link](https://github.com/aio-libs/aiozipkin/blob/89fa9f8cc5d008b0f5ce4d40c2b5af8a42b9c011/aiozipkin/transport.py#L50)) . Each `BatchManager()` stores multiple traces and sends them upstream according to a pooling interval.

Therefore, since every http request has a trace due to the`init_tracer()`, the resulting `aiozipkin` trace also has its associated `BatchManager`.

https://github.com/mchlvl/starlette-zipkin/blob/ff398682e5effa1221096265dd0534cb73212ce1/starlette_zipkin/middleware.py#L34

At the moment, and when the request ends, the `BatchManager` associated to the request trace continues to run forever, even if it has no more events to send and if the request is completed. After a few hundred requests the system will also have hundreds of `BatchManager` and their sleep+push cycle.

This PR invokes `tracer.close()` when (if I understood correctly) there's nothing else to do. So that `BatchManager` sends any remaining traces to the host and closes it.

I've ran the tests and they are all green, but I don't know how to add a new test that prevents doing the same in the future.