### PR TITLE
FIX support external tracer (for tests) as well as an internally manged one

### DIFF
--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -1,4 +1,3 @@
-import asyncio
 import socket
 import traceback
 import urllib

--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -15,11 +15,11 @@ from starlette.types import Scope
 
 from .config import ZipkinConfig
 from .trace import (
+    _tracer_ctx_var,
     get_tracer,
     init_tracer,
     install_root_span,
     reset_root_span,
-    _tracer_ctx_var,
 )
 
 

--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -37,7 +37,8 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         # check for externally provided tracer - if none provided, we will create one and hold on to it to reuse it,
         # similar to https://github.com/aio-libs/aiozipkin/blob/master/examples/aiohttp_example.py
-        if (external_tracer := get_tracer()) is None:
+        external_tracer = get_tracer()
+        if external_tracer is None:
             if self.tracer is None:
                 self.tracer = await init_tracer(self.config)
             # propagate tracer instance via a context variable to other parts of the application

--- a/starlette_zipkin/trace.py
+++ b/starlette_zipkin/trace.py
@@ -41,7 +41,6 @@ async def init_tracer(config: ZipkinConfig) -> az.Tracer:
         endpoint,
         sample_rate=config.sample_rate,
     )
-    _tracer_ctx_var.set(tracer)
     return tracer
 
 


### PR DESCRIPTION
As described in https://github.com/mchlvl/starlette-zipkin/pull/25 by @luminoso, currently we keep creating new `az.Tracer` on every request, while never closing any of them. This was not originally intended, as we planned to only create the `az.Tracer` once and reuse it for every request (while granting easy access via exposed context variable).

That would be similar to creating the `az.Tracer` with `az.create(...)` in the example setup: https://github.com/aio-libs/aiozipkin/blob/master/examples/aiohttp_example.py#L57

This PR solves the leak by allowing for externally provided tracer (for example used in tests), or internally managed one (first request creates the `az.Tracer` and `ZipkinMiddleware` instance holds its state.