### PR TITLE
Keep the tracer reference in the middleware itself

### DIFF
--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -17,6 +17,8 @@ from .trace import init_tracer, install_root_span, reset_root_span
 
 
 class ZipkinMiddleware(BaseHTTPMiddleware):
+    tracer: az.Tracer
+
     def __init__(
         self, app: Starlette, dispatch: Callable = None, config: ZipkinConfig = None
     ):
@@ -24,7 +26,7 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
         self.dispatch_func = self.dispatch if dispatch is None else dispatch
         self.config = config or ZipkinConfig()
         self.validate_config()
-        self.tracer = None
+        self.tracer = None  # Initialized on first dispatch
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint

--- a/starlette_zipkin/trace.py
+++ b/starlette_zipkin/trace.py
@@ -9,8 +9,6 @@ from aiozipkin.span import SpanAbc
 from starlette_zipkin.header_formatters.b3 import B3Headers
 from starlette_zipkin.header_formatters.template import Headers as HeadersFormater
 
-from .config import ZipkinConfig
-
 _tracer_ctx_var: ContextVar[Any] = ContextVar("tracer", default=None)
 _root_span_ctx_var: ContextVar[Any] = ContextVar("root_span", default=None)
 _cur_span_ctx_var: ContextVar[Optional[SpanAbc]] = ContextVar(
@@ -34,15 +32,12 @@ def reset_root_span(tok: Token) -> None:
     _root_span_ctx_var.reset(tok)
 
 
-async def init_tracer(config: ZipkinConfig) -> az.Tracer:
-    endpoint = az.create_endpoint(config.service_name)
-    tracer = await az.create(
-        f"http://{config.host}:{config.port}/api/v2/spans",
-        endpoint,
-        sample_rate=config.sample_rate,
-    )
-    _tracer_ctx_var.set(tracer)
-    return tracer
+def install_tracer(tracer: az.Tracer) -> Token:
+    return _tracer_ctx_var.set(tracer)
+
+
+def reset_tracer(tok: Token) -> None:
+    _tracer_ctx_var.reset(tok)
 
 
 class trace:


### PR DESCRIPTION
So I checkout tag 0.1.2 and then tag 0.2 and your branch.

In 0.1.2, there where a ZipkinMiddleware.tracer attribute initialize on the init_tracer function

```
    async def init_tracer(self) -> None:
        if self.tracer is None:
            endpoint = az.create_endpoint(self.config.service_name)
            tracer = await az.create(
                f"http://{self.config.host}:{self.config.port}/api/v2/spans",
                endpoint,
                sample_rate=self.config.sample_rate,
            )
            self.tracer = tracer
            _tracer_ctx_var.set(tracer)
        else:
            _tracer_ctx_var.set(self.tracer)
```

and it was initialized on the first dispatch


```
    async def dispatch(
        self, request: Request, call_next: RequestResponseEndpoint
    ) -> Response:
        await self.init_tracer()
        tracer = get_tracer()

       ...
        with function(**kw) as span:
            try:
                ...
                return response
            finally:
                ...
        await tracer.close()
```
(I've also note that the tracer.close was an unreachable statement (not in finally) and thankfully because the tracer was not supposed to be closed.)


And, for SOLID principle, Ive move all the ContextVar manipulation in the trace.py module.

```
        tracer = get_tracer()
        if tracer is None:
            tracer = await init_tracer(self.config)
```
and the self.tracer was never initialized (and I should remove it completly.


From what I understand, event after and ` init_tracer(self.config)` the get_tracer() return None and we reinit it ?

If it is the case, I think we can keep the reference in the middleware instance like in this merge request.

I have to do more investigation to confirm that.



