### PR TITLE
Cleanup tests to avoid coroutines of the BatchManager of aiozikin

### DIFF
--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -20,13 +20,17 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
     tracer: az.Tracer
 
     def __init__(
-        self, app: Starlette, dispatch: Callable = None, config: ZipkinConfig = None
+        self,
+        app: Starlette,
+        dispatch: Callable = None,
+        config: ZipkinConfig = None,
+        _tracer: az.Tracer = None,  # dependency injection used for testing
     ):
         self.app = app
         self.dispatch_func = self.dispatch if dispatch is None else dispatch
         self.config = config or ZipkinConfig()
         self.validate_config()
-        self.tracer = None  # Initialized on first dispatch
+        self.tracer = _tracer  # Initialized on first dispatch
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint

--- a/tests/test_b3_headers.py
+++ b/tests/test_b3_headers.py
@@ -2,27 +2,27 @@ from starlette.testclient import TestClient
 from starlette_zipkin import ZipkinMiddleware, ZipkinConfig, B3Headers as Headers
 
 
-def test_sync(app, b3_keys):
+def test_sync(app, tracer, b3_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200
     assert all(key in response.headers for key in b3_keys)
 
 
-def test_async(app, b3_keys):
+def test_async(app, tracer, b3_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/async-message?foo=bar")
     assert response.status_code == 200
     assert all(key in response.headers for key in b3_keys)
 
 
-def test_sync_request_data(app, b3_keys):
+def test_sync_request_data(app, tracer, b3_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200
@@ -43,9 +43,9 @@ def test_sync_request_data(app, b3_keys):
     assert headers["x-b3-spanid"] == response2.headers["x-b3-parentspanid"]
 
 
-def test_async_request_data(app, b3_keys):
+def test_async_request_data(app, tracer, b3_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/async-message?foo=bar")
     assert response.status_code == 200

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,27 +2,27 @@ from starlette.testclient import TestClient
 from starlette_zipkin import ZipkinMiddleware, ZipkinConfig
 
 
-def test_sync_no_inject(app, b3_keys):
+def test_sync_no_inject(app, tracer, b3_keys):
     config = ZipkinConfig(inject_response_headers=False)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200
     assert not any(key in response.headers for key in b3_keys)
 
 
-def test_async_no_inject(app, b3_keys):
+def test_async_no_inject(app, tracer, b3_keys):
     config = ZipkinConfig(inject_response_headers=False)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/async-message?foo=bar")
     assert response.status_code == 200
     assert not any(key in response.headers for key in b3_keys)
 
 
-def test_sync_force_new_trace(app, b3_keys):
+def test_sync_force_new_trace(app, tracer, b3_keys):
     config = ZipkinConfig(force_new_trace=True)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     # call with injected tracing headers - needs to follow up
@@ -35,9 +35,9 @@ def test_sync_force_new_trace(app, b3_keys):
     assert headers["x-b3-traceid"] != response2.headers["x-b3-traceid"]
 
 
-def test_async_force_new_trace(app, b3_keys):
+def test_async_force_new_trace(app, tracer, b3_keys):
     config = ZipkinConfig(force_new_trace=True)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/async-message?foo=bar")
     assert response.status_code == 200

--- a/tests/test_uber_headers.py
+++ b/tests/test_uber_headers.py
@@ -7,27 +7,27 @@ from starlette_zipkin import (
 )
 
 
-def test_sync(app, uber_keys):
+def test_sync(app, tracer, uber_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200
     assert all(key in response.headers for key in uber_keys)
 
 
-def test_async(app, uber_keys):
+def test_async(app, tracer, uber_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/async-message?foo=bar")
     assert response.status_code == 200
     assert all(key in response.headers for key in uber_keys)
 
 
-def test_sync_request_data(app, uber_keys):
+def test_sync_request_data(app, tracer, uber_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200
@@ -51,9 +51,9 @@ def test_sync_request_data(app, uber_keys):
     assert span_id == parent_id2
 
 
-def test_async_request_data(app, uber_keys):
+def test_async_request_data(app, tracer, uber_keys):
     config = ZipkinConfig(header_formatter=Headers)
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/async-message?foo=bar")
     assert response.status_code == 200
@@ -78,9 +78,9 @@ def test_async_request_data(app, uber_keys):
 
 
 @pytest.mark.parametrize("split_char", [(":"), ("%3A")])
-def test_split_char(app, uber_keys, split_char):
+def test_split_char(app, tracer, uber_keys, split_char):
     config = ZipkinConfig(header_formatter=Headers, header_formatter_kwargs=dict(split_char=split_char))
-    app.add_middleware(ZipkinMiddleware, config=config)
+    app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200


### PR DESCRIPTION
Currently tests are creating a `BatchManager` in many tests.

The test_trace module introduce a fixture to avoid it and tests expected trace to be send instead of pushing
them in the batchmanager that cannot process them.

Here is a pull request to reuse the feature in other tests.