### PR TITLE
30 tests are soft complaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/*
 .env
 build/*
 __pycache__
+.coverage
+coverage.xml

--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -39,13 +39,13 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
             self.tracer = await self.init_tracer()
 
         tracer_token = install_tracer(self.tracer)
-
+        kw = {}
+        function = self.tracer.new_trace
         if self.has_trace_id(request) and not self.config.force_new_trace:
-            kw = {"context": self.config.header_formatter.make_context(request.headers)}
-            function = self.tracer.new_child
-        else:
-            kw = {}
-            function = self.tracer.new_trace
+            context = self.config.header_formatter.make_context(request.headers)
+            if context:
+                kw = {"context": context}
+                function = self.tracer.new_child
 
         with function(**kw) as span:
             # set root span using context variable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,12 @@
-import pytest
-
 import aiozipkin as az
+import pytest
 from aiozipkin.transport import TransportABC
-
 from starlette.applications import Starlette
-from starlette.responses import PlainTextResponse
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+
 from starlette_zipkin import B3Headers, UberHeaders
 from starlette_zipkin.trace import _tracer_ctx_var, install_root_span, reset_root_span
-from starlette.requests import Request
-from starlette.responses import Response
 
 
 @pytest.fixture
@@ -85,7 +83,7 @@ class DummyRequest:
         self.body = body
         self.headers = headers or {}
         scpoped_headers = [
-           (k.lower().encode("latin-1"), v.encode("latin-1"))
+            (k.lower().encode("latin-1"), v.encode("latin-1"))
             for k, v in self.headers.items()
         ]
         self.scope = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 from starlette_zipkin import B3Headers, UberHeaders
 from starlette_zipkin.trace import _tracer_ctx_var, install_root_span, reset_root_span
+from starlette.requests import Request
+from starlette.responses import Response
 
 
 @pytest.fixture
@@ -67,3 +69,44 @@ def root_span(tracer):
     tok = install_root_span(span)
     yield span
     reset_root_span(tok)
+
+
+class DummyRequest:
+    def __init__(
+        self,
+        method="GET",
+        scheme="http",
+        path="/",
+        querystring=b"",
+        body=None,
+        headers=None,
+        type_="http",
+    ) -> None:
+        self.body = body
+        self.headers = headers or {}
+        scpoped_headers = [
+           (k.lower().encode("latin-1"), v.encode("latin-1"))
+            for k, v in self.headers.items()
+        ]
+        self.scope = {
+            "type": type_,
+            "scheme": scheme,
+            "method": method,
+            "path": path,
+            "query_string": querystring,
+            "headers": scpoped_headers,
+            "server": ["localhost", 8000],
+        }
+
+
+@pytest.fixture
+def dummy_request():
+    return DummyRequest
+
+
+@pytest.fixture
+def next_response():
+    async def next(request: Request) -> Response:
+        return Response(request.body, headers=dict(request.headers))
+
+    return next

--- a/tests/test_b3_headers.py
+++ b/tests/test_b3_headers.py
@@ -1,5 +1,7 @@
 from starlette.testclient import TestClient
-from starlette_zipkin import ZipkinMiddleware, ZipkinConfig, B3Headers as Headers
+
+from starlette_zipkin import B3Headers as Headers
+from starlette_zipkin import ZipkinConfig, ZipkinMiddleware
 
 
 def test_sync(app, tracer, b3_keys):
@@ -37,8 +39,7 @@ def test_sync_request_data(app, tracer, b3_keys):
     assert all(key in response2.headers for key in b3_keys)
     assert "x-b3-parentspanid" in response2.headers
     assert (
-        headers[Headers.TRACE_ID_HEADER]
-        == response2.headers[Headers.TRACE_ID_HEADER]
+        headers[Headers.TRACE_ID_HEADER] == response2.headers[Headers.TRACE_ID_HEADER]
     )
     assert headers["x-b3-spanid"] == response2.headers["x-b3-parentspanid"]
 
@@ -60,7 +61,6 @@ def test_async_request_data(app, tracer, b3_keys):
     assert all(key in response2.headers for key in b3_keys)
     assert "x-b3-parentspanid" in response2.headers
     assert (
-        headers[Headers.TRACE_ID_HEADER]
-        == response2.headers[Headers.TRACE_ID_HEADER]
+        headers[Headers.TRACE_ID_HEADER] == response2.headers[Headers.TRACE_ID_HEADER]
     )
     assert headers["x-b3-spanid"] == response2.headers["x-b3-parentspanid"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from starlette.testclient import TestClient
-from starlette_zipkin import ZipkinMiddleware, ZipkinConfig
+
+from starlette_zipkin import ZipkinConfig, ZipkinMiddleware
 
 
 def test_sync_no_inject(app, tracer, b3_keys):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -30,6 +30,7 @@ async def test_dispatch_trace_new_child(app, dummy_request, next_response):
         "x-b3-spanid": span_id,
         "x-b3-traceid": trace_id,
     }
+    await middleware.tracer.close()
 
 
 @pytest.mark.asyncio
@@ -54,6 +55,7 @@ async def test_dispatch_trace(app, dummy_request, next_response):
         "x-b3-spanid": resp.headers["x-b3-spanid"],
         "x-b3-traceid": resp.headers["x-b3-traceid"],
     }
+    await middleware.tracer.close()
 
 
 @pytest.mark.asyncio
@@ -82,7 +84,7 @@ async def test_dispatch_trace_buggy_headers(app, dummy_request, next_response):
     }
     # we cannot reuse the traceid if the span id was missing
     assert trace_id != resp.headers["x-b3-spanid"]
-
+    await middleware.tracer.close()
 
 @pytest.mark.asyncio
 async def test_dispatch_trace_reuse_tracer(app, dummy_request, next_response):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -34,7 +34,7 @@ async def test_dispatch_trace_new_child(app, dummy_request, next_response):
 
 @pytest.mark.asyncio
 async def test_dispatch_trace(app, dummy_request, next_response):
-    config = ZipkinConfig("zipkin.host")
+    config = ZipkinConfig()
     middleware = ZipkinMiddleware(app, config=config)
     # the tracer is initialized on the first dispatch
     assert middleware.tracer is None
@@ -46,7 +46,7 @@ async def test_dispatch_trace(app, dummy_request, next_response):
     assert middleware.tracer._transport is not None
     assert (
         str(middleware.tracer._transport._address)
-        == "http://zipkin.host:9411/api/v2/spans"
+        == "http://localhost:9411/api/v2/spans"
     )
     assert dict(resp.headers) == {
         "x-b3-flags": "0",
@@ -59,7 +59,7 @@ async def test_dispatch_trace(app, dummy_request, next_response):
 @pytest.mark.asyncio
 async def test_dispatch_trace_buggy_headers(app, dummy_request, next_response):
     trace_id = "6223635aa7bfb6597d72ac7c4680bfed"
-    config = ZipkinConfig("zipkin.host")
+    config = ZipkinConfig()
     middleware = ZipkinMiddleware(app, config=config)
     # the tracer is initialized on the first dispatch
     assert middleware.tracer is None
@@ -74,10 +74,6 @@ async def test_dispatch_trace_buggy_headers(app, dummy_request, next_response):
     )
     assert middleware.tracer is not None
     assert middleware.tracer._transport is not None
-    assert (
-        str(middleware.tracer._transport._address)
-        == "http://zipkin.host:9411/api/v2/spans"
-    )
     assert dict(resp.headers) == {
         "x-b3-flags": "0",
         "x-b3-sampled": "1",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -54,3 +54,35 @@ async def test_dispatch_trace(app, dummy_request, next_response):
         "x-b3-spanid": resp.headers["x-b3-spanid"],
         "x-b3-traceid": resp.headers["x-b3-traceid"],
     }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_trace_buggy_headers(app, dummy_request, next_response):
+    trace_id = "6223635aa7bfb6597d72ac7c4680bfed"
+    config = ZipkinConfig("zipkin.host")
+    middleware = ZipkinMiddleware(app, config=config)
+    # the tracer is initialized on the first dispatch
+    assert middleware.tracer is None
+    resp = await middleware.dispatch(
+        dummy_request(
+            headers={
+                "x-b3-traceid": trace_id,
+                # x-b3-spanid should be here
+            }
+        ),
+        next_response,
+    )
+    assert middleware.tracer is not None
+    assert middleware.tracer._transport is not None
+    assert (
+        str(middleware.tracer._transport._address)
+        == "http://zipkin.host:9411/api/v2/spans"
+    )
+    assert dict(resp.headers) == {
+        "x-b3-flags": "0",
+        "x-b3-sampled": "1",
+        "x-b3-spanid": resp.headers["x-b3-spanid"],
+        "x-b3-traceid": resp.headers["x-b3-traceid"],
+    }
+    # we cannot reuse the traceid if the span id was missing
+    assert trace_id != resp.headers["x-b3-spanid"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,56 @@
+import pytest
+
+from starlette_zipkin import ZipkinMiddleware, ZipkinConfig
+
+
+@pytest.mark.asyncio
+async def test_dispatch_trace_new_child(app, dummy_request, next_response):
+    trace_id = "6223635aa7bfb6597d72ac7c4680bfed"
+    span_id = "ac7cb16943218de4"
+    config = ZipkinConfig("zipkin.host")
+    middleware = ZipkinMiddleware(app, config=config)
+    # the tracer is initialized on the first dispatch
+    assert middleware.tracer is None
+    resp = await middleware.dispatch(
+        dummy_request(
+            headers={
+                "x-b3-spanid": span_id,
+                "x-b3-traceid": trace_id,
+            }
+        ),
+        next_response,
+    )
+    assert middleware.tracer is not None
+    assert middleware.tracer._transport is not None
+    assert (
+        str(middleware.tracer._transport._address)
+        == "http://zipkin.host:9411/api/v2/spans"
+    )
+    assert dict(resp.headers) == {
+        "x-b3-spanid": span_id,
+        "x-b3-traceid": trace_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_trace(app, dummy_request, next_response):
+    config = ZipkinConfig("zipkin.host")
+    middleware = ZipkinMiddleware(app, config=config)
+    # the tracer is initialized on the first dispatch
+    assert middleware.tracer is None
+    resp = await middleware.dispatch(
+        dummy_request(headers={}),
+        next_response,
+    )
+    assert middleware.tracer is not None
+    assert middleware.tracer._transport is not None
+    assert (
+        str(middleware.tracer._transport._address)
+        == "http://zipkin.host:9411/api/v2/spans"
+    )
+    assert dict(resp.headers) == {
+        "x-b3-flags": "0",
+        "x-b3-sampled": "1",
+        "x-b3-spanid": resp.headers["x-b3-spanid"],
+        "x-b3-traceid": resp.headers["x-b3-traceid"],
+    }

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -95,3 +95,16 @@ async def test_dispatch_trace_reuse_tracer(app, dummy_request, next_response):
     tracer = middleware.tracer
     await middleware.dispatch(dummy_request(), next_response)
     assert middleware.tracer is tracer, "Tracer must be reused on every requests"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_trace_reuse_tracer(app, dummy_request, next_response):
+    config = ZipkinConfig()
+    middleware = ZipkinMiddleware(app, config=config)
+    # the tracer is initialized on the first dispatch
+    assert middleware.tracer is None
+    await middleware.dispatch(dummy_request(), next_response)
+    assert middleware.tracer is not None
+    tracer = middleware.tracer
+    await middleware.dispatch(dummy_request(), next_response)
+    assert middleware.tracer is tracer, "Tracer must be reused on every requests"

--- a/tests/test_uber_headers.py
+++ b/tests/test_uber_headers.py
@@ -1,10 +1,8 @@
 import pytest
 from starlette.testclient import TestClient
-from starlette_zipkin import (
-    ZipkinMiddleware,
-    ZipkinConfig,
-    UberHeaders as Headers,
-)
+
+from starlette_zipkin import UberHeaders as Headers
+from starlette_zipkin import ZipkinConfig, ZipkinMiddleware
 
 
 def test_sync(app, tracer, uber_keys):
@@ -79,11 +77,13 @@ def test_async_request_data(app, tracer, uber_keys):
 
 @pytest.mark.parametrize("split_char", [(":"), ("%3A")])
 def test_split_char(app, tracer, uber_keys, split_char):
-    config = ZipkinConfig(header_formatter=Headers, header_formatter_kwargs=dict(split_char=split_char))
+    config = ZipkinConfig(
+        header_formatter=Headers, header_formatter_kwargs=dict(split_char=split_char)
+    )
     app.add_middleware(ZipkinMiddleware, config=config, _tracer=tracer)
     client = TestClient(app)
     response = client.get("/sync-message?foo=bar")
     assert response.status_code == 200
     assert all(key in response.headers for key in uber_keys)
-    item = response.headers.get('uber-trace-id')
+    item = response.headers.get("uber-trace-id")
     assert split_char in item


### PR DESCRIPTION
Here is a second pass of the tests where we add unit tests of the middleware.

some tests does not override the transport and the `await middleware.tracer.close()` is used at the end of the tests.
(it could be improved by using a pytest fixture actually.)

The tests `test_dispatch_trace_reuse_tracer` is written to ensure the tracer is reused.

I also update the code to use `new_trace` instead of raising 500 errors if the call contains invalid zipkin headers ( a trace without a span for instance )


