### PR TITLE
Prevent get_ip from raising an exception if hostname does not resolve

### DIFF
--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -31,6 +31,7 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
         self.config = config or ZipkinConfig()
         self.validate_config()
         self.tracer = _tracer  # Initialized on first dispatch
+        self.host_ip = get_ip()
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
@@ -88,7 +89,7 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
         name = f'{scope["scheme"].upper()} {scope["method"]} {scope["path"]}'
         span.name(name)
         span.tag("component", "asgi")
-        span.tag("ip", get_ip())
+        span.tag("ip", self.host_ip)
         span.kind(az.SERVER)
 
         if scope["type"] in {"http", "websocket"}:

--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -188,4 +188,3 @@ def get_ip() -> Any:
         return socket.gethostbyname(hostname)
     except socket.gaierror:
         return socket.gethostbyname("")
-

--- a/starlette_zipkin/middleware.py
+++ b/starlette_zipkin/middleware.py
@@ -183,5 +183,9 @@ class ZipkinMiddleware(BaseHTTPMiddleware):
 
 
 def get_ip() -> Any:
-    hostname = socket.gethostname()
-    return socket.gethostbyname(hostname)
+    try:
+        hostname = socket.gethostname()
+        return socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return socket.gethostbyname("")
+

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,6 @@
 import pytest
 
-from starlette_zipkin import ZipkinConfig, ZipkinMiddleware
+from starlette_zipkin import ZipkinConfig, ZipkinMiddleware, middleware
 
 
 @pytest.mark.asyncio
@@ -171,3 +171,11 @@ def test_get_transaction(app, params):
     middleware = ZipkinMiddleware(app, config=config)
     transac = middleware.get_transaction({"endpoint": params["endpoint"]})
     assert transac == params["expected"]
+
+def test_get_ip_with_hostname_that_resolves(monkeypatch):
+    monkeypatch.setattr(middleware.socket, "gethostname", lambda: "localhost")
+    assert middleware.get_ip() == "127.0.0.1"
+
+def test_get_ip_without_hostname_that_resolves(monkeypatch):
+    monkeypatch.setattr(middleware.socket, "gethostname", lambda: "thishostnamewontresolve")
+    assert middleware.get_ip() == "0.0.0.0"


### PR DESCRIPTION
While attempting to use this in a project, I noticed that get_ip would raise the following exception when I integrate the middleware into my FastAPI app:

```
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```

This was because my work laptop has a hostname that is not in /etc/hosts and is not in any DNS server. While this shouldn't be a problem in production, this makes local development using the middleware unusable unless you change your local hosts file. Instead, following the advice in [this StackOverflow post](https://stackoverflow.com/questions/39970606/gaierror-errno-8-nodename-nor-servname-provided-or-not-known-with-macos-sie), I changed `get_ip` to catch this specific exception and use a default value instead. This seemed preferable to having a tracing middleware blow up request processing if DNS resolution fails.

Funny enough, all the tests in this repo fail with the same error without this change, and pass with this change, so that + it working in my app was the level of testing done for this change. 😄 

Before:
```
============================================================================ short test summary info ============================================================================
FAILED tests/test_b3_headers.py::test_sync - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_b3_headers.py::test_async - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_b3_headers.py::test_sync_request_data - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_b3_headers.py::test_async_request_data - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_config.py::test_sync_no_inject - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_config.py::test_async_no_inject - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_config.py::test_sync_force_new_trace - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_config.py::test_async_force_new_trace - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_middleware.py::test_dispatch_trace_new_child - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_middleware.py::test_dispatch_trace - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_middleware.py::test_dispatch_trace_buggy_headers - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_middleware.py::test_dispatch_trace_reuse_tracer - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_uber_headers.py::test_sync - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_uber_headers.py::test_async - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_uber_headers.py::test_sync_request_data - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_uber_headers.py::test_async_request_data - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_uber_headers.py::test_split_char[:] - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/test_uber_headers.py::test_split_char[%3A] - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
========================================================================= 18 failed, 16 passed in 0.86s =========================================================================
```

After
```
============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/maahmed/Code/starlette-zipkin
plugins: asyncio-0.16.0, cov-2.10.1
collected 34 items                                                                                                                                                              

tests/test_b3_headers.py ....                                                                                                                                             [ 11%]
tests/test_config.py ....                                                                                                                                                 [ 23%]
tests/test_middleware.py .............                                                                                                                                    [ 61%]
tests/test_trace.py .......                                                                                                                                               [ 82%]
tests/test_uber_headers.py ......                                                                                                                                         [100%]

============================================================================== 34 passed in 0.20s ===============================================================================
```