### PR TITLE
FIX continue when no middleware added to the app

### DIFF
--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -171,7 +171,6 @@ def test_headers(root_span):
 
 def test_trace_without_middleware():
     """Test the code passes through without the instrumenting middleware"""
-    dummy_trace = None
     with trace("my dummy trace") as span:
         span.annotate("dummy annotation")
         span.tag("key", "value")
@@ -186,7 +185,6 @@ def test_trace_without_middleware():
 @pytest.mark.asyncio
 async def test_trace_without_middleware_async():
     """Test the code passes through without the instrumenting middleware"""
-    dummy_trace = None
     async with trace("my dummy trace") as span:
         span.annotate("dummy annotation")
         span.tag("key", "value")

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -167,3 +167,32 @@ def test_headers(root_span):
             "X-B3-SpanId": child_span._span.context.span_id,
             "X-B3-TraceId": child_span.trace_id,
         }
+
+
+def test_trace_without_middleware():
+    """Test the code passes through without the instrumenting middleware"""
+    dummy_trace = None
+    with trace("my dummy trace") as span:
+        span.annotate("dummy annotation")
+        span.tag("key", "value")
+        trace_id = span.trace_id
+        headers = span.make_headers()
+        dummy_trace = _cur_span_ctx_var.get()
+    assert dummy_trace is None
+    assert trace_id is None
+    assert headers == {}
+
+
+@pytest.mark.asyncio
+async def test_trace_without_middleware_async():
+    """Test the code passes through without the instrumenting middleware"""
+    dummy_trace = None
+    async with trace("my dummy trace") as span:
+        span.annotate("dummy annotation")
+        span.tag("key", "value")
+        trace_id = span.trace_id
+        headers = span.make_headers()
+        dummy_trace = _cur_span_ctx_var.get()
+    assert dummy_trace is None
+    assert trace_id is None
+    assert headers == {}


### PR DESCRIPTION
tackles https://github.com/mchlvl/starlette-zipkin/issues/35 by silently passing back the objects when not instrumented by the middleware

Pros
- This is helpful for situations when user removes the middleware, but relies on the trace context manager for application code to run.

Cons
- extra logic that can change behavior "silently" when middleware is removed
- Could be solved by writing the code differently, however this seems like a reasonable usecase that could have such convenience handling
- Does not catch attribute errors when accessing the original aiozipkin objects (e.g. `child_span._span.context`). However, might be sufficient if the handling is done on native methods that are wrapped in the `trace` object