### PR TITLE
v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.4 (July 5, 2022)
+
+### Changed
+- [PR36](https://github.com/mchlvl/starlette-zipkin/pull/36) application can operate when middleware is not added (trace decorator and related methods pass through silently)
 
 ## 0.2.3 (April 1, 2022)
 
-## Fixed
+### Fixed
 - [PR33](https://github.com/mchlvl/starlette-zipkin/pull/33) updates test setup
 - [PR34](https://github.com/mchlvl/starlette-zipkin/pull/34) handles edge case when ip cannot be resolved
 

--- a/starlette_zipkin/__init__.py
+++ b/starlette_zipkin/__init__.py
@@ -2,7 +2,7 @@ from starlette_zipkin.header_formatters import B3Headers, UberHeaders
 from starlette_zipkin.middleware import ZipkinConfig, ZipkinMiddleware, get_ip
 from starlette_zipkin.trace import get_root_span, get_tracer, trace
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __all__ = [
     "ZipkinConfig",
     "ZipkinMiddleware",


### PR DESCRIPTION
## 0.2.4 (July 5, 2022)

### Changed
- [PR36](https://github.com/mchlvl/starlette-zipkin/pull/36) application can operate when middleware is not added (trace decorator and related methods pass through silently)
