### PR TITLE
Fix 404 link from pypi to github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_packages(package):
 setup(
     name="starlette-zipkin",
     version=get_version("starlette_zipkin"),
-    url="https://github.com/mchlvl/starlette_zipkin",
+    url="https://github.com/mchlvl/starlette-zipkin",
     license="BSD",
     description="Zipkin integration for ASGI frameworks.",
     long_description=get_long_description(),


### PR DESCRIPTION
Hi @mchlvl 

The link to the home page here is encountouring a 404 error.

https://pypi.org/project/starlette-zipkin/


![image](https://github.com/mchlvl/starlette-zipkin/assets/447396/781d8888-d0a0-41d2-b7b0-0ee34e5fa4e1)
